### PR TITLE
fix: Revert "chore: Use the same log level as mender-mcu"

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -13,7 +13,7 @@
 //    limitations under the License.
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(mender_app, CONFIG_MENDER_LOG_LEVEL);
+LOG_MODULE_REGISTER(mender_app, LOG_LEVEL_DBG);
 
 #include "utils/netup.h"
 #include "utils/certs.h"


### PR DESCRIPTION
We get linking errors because `CONFIG_MENDER_LOG_LEVEL` is only defined in the `mender-mcu` module. In addition, it might be better to keep the log-levels contained within a module.

This reverts commit 6e00f35c4c331e5396587030f3188fe768e92fa3.

Ticket: None
Changelog: Title