### PR TITLE
chore: include <stdio.h> to remove compilation warnings

### DIFF
--- a/src/utils/netup.c
+++ b/src/utils/netup.c
@@ -27,6 +27,7 @@ LOG_MODULE_DECLARE(mender_app, LOG_LEVEL_DBG);
 
 #include "netup.h"
 
+#include <stdio.h>
 #include <assert.h>
 
 #include <zephyr/kernel.h>


### PR DESCRIPTION
Removes 'implicit declaration of snprintf' warnings

Ticket: None