### PR TITLE
ci: jobs to build workspace and board

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,4 +6,61 @@ include:
       - '.gitlab-ci-check-license.yml'
 
 stages:
+  - build
   - test
+
+variables:
+  MENDER_MCU_REVISION: v0.2-update-modules
+  IMAGE_VERSION: main
+
+.boards-matrix:
+  parallel:
+    matrix:
+      - MENDER_MCU_BOARD: [esp32_ethernet_kit/esp32/procpu, esp32s3_devkitc/esp32s3/procpu, olimex_esp32_evb/esp32/procpu, mr_canhubk3, native_sim]
+
+.build-template:
+  tags:
+    - hetzner-amd-beefy
+  stage: build
+  variables:
+    CONTAINER_TAG: "west-workspace"
+
+build:workspace:
+  extends: .build-template
+  services:
+    - docker:dind
+  script:
+    - echo "INFO - Building and Pushing ${CONTAINER_TAG}-${CI_PIPELINE_ID} to the registry ${CI_REGISTRY_IMAGE}"
+    - echo $CI_REGISTRY_PASSWORD | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
+    - docker build
+        --cache-from ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-main
+        --file Dockerfile.ci
+        --tag ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-${CI_COMMIT_BRANCH}
+        --push
+        .
+    - echo "IMAGE_VERSION=$CI_COMMIT_BRANCH" >> image_version.env
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+    # Rebuild the workspace image if the Dockerfile.ci changes
+    - changes:
+        paths:
+          - Dockerfile.ci
+        compare_to: main
+  artifacts:
+    reports:
+      dotenv: image_version.env
+
+
+build:board:
+  extends: .build-template
+  image: ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-${IMAGE_VERSION}
+  needs:
+    - job: build:workspace
+      optional: true
+  script:
+    - west update --narrow -o=--depth=1 --path-cache /zephyr-workspace-cache
+    - echo "Building for ${MENDER_MCU_BOARD} with revision ${MENDER_MCU_REVISION}"
+    - cd ../modules/mender-mcu && git fetch mender
+    - git checkout mender/${MENDER_MCU_REVISION} && cd -
+    - west build --board ${MENDER_MCU_BOARD}
+  parallel: !reference [.boards-matrix, parallel]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,46 @@
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+# https://docs.zephyrproject.org/3.7.0/develop/getting_started/index.html#install-dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  pip \
+  ccache \
+  cmake \
+  file \
+  g++-multilib \
+  gcc \
+  gcc-multilib \
+  git \
+  gperf \
+  make \
+  ninja-build \
+  wget \
+  xz-utils
+
+ARG ZEPHYR_SDK_VERSION=0.17.0
+RUN mkdir /opt/toolchains && wget -qO- https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VERSION}/zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64_minimal.tar.xz \
+  | tar -xJ -C /opt/toolchains \
+  && /opt/toolchains/zephyr-sdk-${ZEPHYR_SDK_VERSION}/setup.sh -c \
+  -t arm-zephyr-eabi \
+  -t xtensa-espressif_esp32_zephyr-elf \
+  -t xtensa-espressif_esp32s3_zephyr-elf
+
+# tell cmake where to find the Zephyr SDK cmake packages
+ENV CMAKE_PREFIX_PATH=/opt/toolchains
+
+RUN pip install --no-cache-dir west==1.2.0 --break-system-packages
+
+COPY west.yml /zephyr-workspace-cache/.manifest/west.yml
+
+# Create a cache of the workspace
+RUN cd /zephyr-workspace-cache \
+  && west init -l .manifest \
+  && west update --narrow --fetch-opt=--filter=tree:0
+
+# install Python dependencies for the Zephyr workspace
+RUN cd /zephyr-workspace-cache \
+  && pip install --no-cache-dir -r zephyr/scripts/requirements.txt --break-system-packages
+
+# Fix ESP32 build libraries not found error
+RUN cd /zephyr-workspace-cache \
+  && west blobs fetch hal_espressif


### PR DESCRIPTION
Added a job that creates a docker image with a workspace containing the zephyr sdk with as few toolchains as possible and a cached version of mender-mcu-integration.

Added a job that utilizes this image and the cached workspace to build all the supported boards. You can also specify the revision of mender-mcu by manually changing `MENDER_MCU_REVISION`.

Ticket: MEN-7597