### PR TITLE
fix: Reduce the size of the MbedTLS' heap buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,3 +31,5 @@ generate_inc_file_for_target(app
     "certs/GoogleRootR4.cer"
     "${ZEPHYR_BINARY_DIR}/include/generated/GoogleRootR4.cer.inc"
 )
+
+file(COPY_FILE "config-tls-mender.h" "${ZEPHYR_BINARY_DIR}/include/generated/config-tls-mender.h")

--- a/config-tls-mender.h
+++ b/config-tls-mender.h
@@ -1,0 +1,25 @@
+// Copyright 2025 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+/* Zephyr's config-tls-generic.h defines this macro to the value of
+   CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN. However, that config value is used for
+   both input and output content and we can only use smaller output content
+   length because how much data is sent to us is not under our control (the
+   max_fragment_len TLS 1.2 extension seems to be ignored by the webservers we
+   communicate with). Prevent redefinition warnings by undefining the macro
+   first. */
+#ifdef MBEDTLS_SSL_OUT_CONTENT_LEN
+#undef MBEDTLS_SSL_OUT_CONTENT_LEN
+#endif
+#define MBEDTLS_SSL_OUT_CONTENT_LEN 2048

--- a/prj.conf
+++ b/prj.conf
@@ -45,8 +45,13 @@ CONFIG_MBEDTLS_SERVER_NAME_INDICATION=y
 CONFIG_MBEDTLS_PK_WRITE_C=y
 CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN=16384
 CONFIG_MBEDTLS_ENABLE_HEAP=y
-CONFIG_MBEDTLS_HEAP_SIZE=60000
+CONFIG_MBEDTLS_HEAP_SIZE=34816
 CONFIG_MBEDTLS_ZEPHYR_ENTROPY=y
+
+# We need to use our own extension to the config file to limit the size of the
+# TLS output buffer. See the config and/or MEN-7807 for details.
+CONFIG_MBEDTLS_USER_CONFIG_ENABLE=y
+CONFIG_MBEDTLS_USER_CONFIG_FILE="config-tls-mender.h"
 
 
 ####################################


### PR DESCRIPTION
By reducing the size of the TLS output buffer we can also reduce the size of the MbedTLS' heap buffer (where MbedTLS allocates its internal buffers from).

Ticket: MEN-7807
Changelog: none