### PR TITLE
Update Zephyr to v4.0.0 and use main mender-mcu

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ stages:
   - test
 
 variables:
-  MENDER_MCU_REVISION: v0.3-inventory
+  MENDER_MCU_REVISION: main
   IMAGE_VERSION: main
   DOCKER_VERSION:
     value: "27.3"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,10 +52,11 @@ build:workspace:
     - echo "IMAGE_VERSION=$CI_COMMIT_BRANCH" >> image_version.env
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
-    # Rebuild the workspace image if the Dockerfile.ci changes
+    # Rebuild the workspace image if the Dockerfile.ci or west.yml changes
     - changes:
         paths:
           - Dockerfile.ci
+          - west.yml
         compare_to: main
   artifacts:
     reports:

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,25 +1,31 @@
 FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-# https://docs.zephyrproject.org/3.7.0/develop/getting_started/index.html#install-dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  pip \
-  ccache \
+# https://docs.zephyrproject.org/4.0.0/develop/getting_started/index.html#install-dependencies
+RUN apt-get update && apt install -y --no-install-recommends \
+  git \
   cmake \
+  ninja-build \
+  gperf \
+  ccache \
+  dfu-util \
+  device-tree-compiler \
+  wget \
+  python3-dev \
+  python3-pip \
+  python3-setuptools \
+  python3-tk \
+  python3-wheel \
+  xz-utils \
   file \
-  g++-multilib \
+  make \
   gcc \
   gcc-multilib \
-  git \
-  gperf \
-  make \
-  ninja-build \
-  wget \
-  xz-utils
+  g++-multilib \
+  libsdl2-dev \
+  libmagic1
 
-# Using 0.16.x series to workaround issue with Espressif SDK missing suseconds_t definition
-# It was been reported upstream and they will fix in the near future
-ARG ZEPHYR_SDK_VERSION=0.16.9
+ARG ZEPHYR_SDK_VERSION=0.17.0
 
 RUN mkdir /opt/toolchains && wget -qO- https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VERSION}/zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64_minimal.tar.xz \
   | tar -xJ -C /opt/toolchains \

--- a/boards/esp32_ethernet_kit_procpu.conf
+++ b/boards/esp32_ethernet_kit_procpu.conf
@@ -3,3 +3,6 @@
 ####################################
 CONFIG_ETH_ESP32=y
 CONFIG_NET_L2_ETHERNET=y
+
+# Linking errors when enabled
+CONFIG_ESP_SPIRAM=n

--- a/prj.conf
+++ b/prj.conf
@@ -46,7 +46,8 @@ CONFIG_MBEDTLS_PK_WRITE_C=y
 CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN=16384
 CONFIG_MBEDTLS_ENABLE_HEAP=y
 CONFIG_MBEDTLS_HEAP_SIZE=34816
-CONFIG_MBEDTLS_ZEPHYR_ENTROPY=y
+CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR=y
+CONFIG_MBEDTLS_ENTROPY_C=y
 
 # We need to use our own extension to the config file to limit the size of the
 # TLS output buffer. See the config and/or MEN-7807 for details.
@@ -63,7 +64,9 @@ CONFIG_MAIN_STACK_SIZE=2048
 # Default is 1024
 # https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-
+# Default is 4
+# https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_ZVFS_OPEN_MAX
+CONFIG_ZVFS_OPEN_MAX=5
 
 ####################################
 # Zephyr logging
@@ -97,7 +100,8 @@ CONFIG_DNS_RESOLVER_ADDITIONAL_BUF_CTR=5
 CONFIG_DNS_RESOLVER_ADDITIONAL_QUERIES=2
 CONFIG_DNS_RESOLVER_MAX_SERVERS=2
 CONFIG_DNS_NUM_CONCUR_QUERIES=5
-
+# Avoid timeouts before recieving SYN-ACK from peer at default value (3000)
+CONFIG_NET_SOCKETS_CONNECT_TIMEOUT=5000
 
 ####################################
 # Developer zone

--- a/src/main.c
+++ b/src/main.c
@@ -64,7 +64,7 @@ static char              mac_address[18] = { 0 };
 static mender_identity_t mender_identity = { .name = "mac", .value = mac_address };
 
 static mender_err_t
-get_identity_cb(mender_identity_t **identity) {
+get_identity_cb(const mender_identity_t **identity) {
     LOG_DBG("get_identity_cb");
     if (NULL != identity) {
         *identity = &mender_identity;

--- a/west.yml
+++ b/west.yml
@@ -9,11 +9,11 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v3.7.0
+      revision: v4.0.0
       import: true
     - name: mender-mcu
       remote: mender
-      revision: v0.3-inventory
+      revision: main
       path: modules/mender-mcu
       import: true
 


### PR DESCRIPTION
The updated config options are really just based on trial and error on arm. The net socket timeout can probably be set a bit higher, same with the max open file descriptors; what do you think a reasonable value is?