### PR TITLE
chore: filter imported modules with allowlist

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -10,7 +10,14 @@ manifest:
     - name: zephyr
       remote: zephyrproject-rtos
       revision: v4.0.0
-      import: true
+      import:
+        name-allowlist:
+          - cmsis
+          - mbedtls
+          - mcuboot
+          - hal_nxp
+          - hal_nordic
+          - hal_espressif
     - name: mender-mcu
       remote: mender
       revision: main


### PR DESCRIPTION
Allowlist allows us to only import the modules we need for our project. By default, every module from Zephyr is included.