### PR TITLE
ci: allow `MENDER_MCU_REVISION` to fetch PR branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,7 +73,7 @@ build:board:
     - cd /zephyr-workspace-cache
     - west update --narrow -o=--depth=1 --path-cache /zephyr-workspace-cache
     - echo "Building for ${MENDER_MCU_BOARD} with revision ${MENDER_MCU_REVISION}"
-    - cd modules/mender-mcu && git fetch mender
-    - git checkout mender/${MENDER_MCU_REVISION} && cd -
+    - cd modules/mender-mcu && git fetch mender ${MENDER_MCU_REVISION}
+    - git checkout FETCH_HEAD && cd -
     - west build --board ${MENDER_MCU_BOARD} ${CI_PROJECT_DIR}
   parallel: !reference [.boards-matrix, parallel]


### PR DESCRIPTION
Makes it possible to checkout to branches like `pull/123/head`