### PR TITLE
ci: don't rebuild workspace unnecessarily on triggers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ build:workspace:
         .
     - echo "IMAGE_VERSION=$CI_COMMIT_BRANCH" >> image_version.env
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE != "pipeline"
     # Rebuild the workspace image if the Dockerfile.ci or west.yml changes
     - changes:
         paths:


### PR DESCRIPTION
There is no need to rebuild the workspace each time we trigger this pipeline from mender-mcu.