### PR TITLE
test: add coverage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ include:
 stages:
   - build
   - test
+  - publish
 
 variables:
   MENDER_MCU_REVISION: main
@@ -77,3 +78,34 @@ build:board:
     - git checkout FETCH_HEAD && cd -
     - west build --board ${MENDER_MCU_BOARD} ${CI_PROJECT_DIR}
   parallel: !reference [.boards-matrix, parallel]
+
+
+publish:tests:
+  stage: publish
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/python:3.11
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "pipeline"
+    # TODO: remove when tests run in pipeline
+    # We don't have anything to publish yet
+    - when: never
+  before_script:
+    # Install dependencies
+    - apt update && apt install -yyq lcov
+    - pip install cpp-coveralls pyyaml
+
+    # eddyxu/cpp-coveralls appears dead, but there doesn't seem to be an
+    # alternative. Use this patch from someone who attempted to fix it. An
+    # alternative to this is to use pyyaml<6, but it's better to use just one
+    # old component than two.
+    - curl -f https://github.com/eddyxu/cpp-coveralls/commit/067c837c04e039e8c70aa53bceda1cded6751408.patch | patch -f /usr/local/lib/python3.11/site-packages/cpp_coveralls/__init__.py
+
+    # Set "TRAVIS_*" variables based on GitLab ones
+    - export TRAVIS_BRANCH=$PARENT_MENDER_MCU_COMMIT_BRANCH
+    - export TRAVIS_JOB_ID=$PARENT_MENDER_MCU_PIPELINE_ID
+
+  script:
+    - 'echo "service_name: gitlab-ci" > .coveralls.yml'
+    - cpp-coveralls
+      --repo-token ${MENDER_MCU_COVERALLS_TOKEN}
+      --no-gcov
+      --lcov-file tests/integration/coverage.lcov

--- a/tests/integration/device.py
+++ b/tests/integration/device.py
@@ -24,8 +24,7 @@ logger = logging.getLogger(__name__)
 
 from helpers import stdout
 from helpers import create_header_file
-
-THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+from helpers import THIS_DIR
 
 # This has to point the west workspace containing mender-mcu-integration
 WORKSPACE_DIRECTORY = os.path.join(THIS_DIR, "../../")
@@ -56,7 +55,7 @@ class DeviceStatus:
 
 
 class NativeSim:
-    def __init__(self, stdout=False):
+    def __init__(self, build_dir, stdout=False):
         self.tenant_token = "..."
         self.proc = None
         self.stdout = stdout
@@ -71,7 +70,7 @@ class NativeSim:
 
         create_header_file()
 
-        self.build_dir = tempfile.mkdtemp()
+        self.build_dir = build_dir
 
     def set_host(self, host="https://docker.mender.io"):
         self.server_host = host
@@ -84,6 +83,7 @@ class NativeSim:
             extra_variables = []
         if compile:
             variables = [
+                "-DCONFIG_COVERAGE=y",
                 "-DBUILD_INTEGRATION_TESTS=ON",
                 f'-DCONFIG_MENDER_SERVER_HOST="{self.server_host}"',
                 f'-DCONFIG_MENDER_SERVER_TENANT_TOKEN="{self.server_tenant}"',

--- a/tests/integration/test_mender_mcu.py
+++ b/tests/integration/test_mender_mcu.py
@@ -33,7 +33,7 @@ def teardown():
         os.remove(helpers.get_header_file())
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def check_variables():
     missing_vars = []
     for var in ("TEST_DEVICE_ID", "TEST_TENANT_TOKEN", "TEST_AUTH_TOKEN"):
@@ -43,7 +43,7 @@ def check_variables():
         pytest.fail(f"Failed to set {', '.join(missing_vars)}")
 
 
-def test_deployment_abort(teardown, server, check_variables):
+def test_deployment_abort(teardown, server, get_build_dir):
 
     """
     Sample test to demonstrate use of framework
@@ -65,7 +65,7 @@ def test_deployment_abort(teardown, server, check_variables):
     """
     helpers.set_callback(definitions.UM_DOWNLOAD_CALLBACK, download_body)
 
-    device = NativeSim(stdout=True)
+    device = NativeSim(get_build_dir, stdout=True)
     # Set host and tenant in the device
     device.set_host("https://hosted.mender.io")
 
@@ -89,6 +89,8 @@ def test_deployment_abort(teardown, server, check_variables):
             break
 
     if not device.status.is_aborted(timeout=60):
+        device.stop()
         pytest.fail("Deployment did not abort")
 
+    device.stop()
     logger.info("Deployment aborted")


### PR DESCRIPTION
I haven't been able test the coverage job in ci yet - but it's essentially a copy of the job in mender-mcu with the variables swapped out. 

The build-dir situation got a bit messy - so I landed on a fixture, which adds an extra argument to the device constructor, but I guess it's fine, unless anyone else has a better idea.