### PR TITLE
Rebase feature integration tests branch

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(mender_app, LOG_LEVEL_DBG);
 #include <zephyr/kernel.h>
 #include <zephyr/sys/reboot.h>
 
+#include <mender/utils.h>
 #include <mender/client.h>
 #include <mender/inventory.h>
 

--- a/src/utils/callbacks.h
+++ b/src/utils/callbacks.h
@@ -12,7 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "mender-client.h"
+#include <mender/client.h>
 
 #ifndef __MENDER_CALLBACKS_H__
 #define __MENDER_CALLBACKS_H__

--- a/tests/integration/src/modules/test-update-module.c
+++ b/tests/integration/src/modules/test-update-module.c
@@ -12,16 +12,12 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "mender-client.h"
-#include "mender-log.h"
-#include "mender-utils.h"
-#include "mender-update-module.h"
-#include <stdio.h>
-#include <stdlib.h>
+#include <mender/alloc.h>
+#include <mender/client.h>
+#include <mender/log.h>
+#include <mender/utils.h>
+#include <mender/update-module.h>
 
-#include "zephyr/kernel.h"
-
-#include "mender-utils.h"
 
 #include <zephyr/kernel.h>
 

--- a/tests/integration/src/modules/test-update-module.c
+++ b/tests/integration/src/modules/test-update-module.c
@@ -52,7 +52,7 @@ test_update_module_register(void) {
     mender_update_module_t *test_update_module;
 
     /* Register the zephyr-image update module */
-    if (NULL == (test_update_module = calloc(1, sizeof(mender_update_module_t)))) {
+    if (NULL == (test_update_module = mender_calloc(1, sizeof(mender_update_module_t)))) {
         mender_log_error("Unable to allocate memory for the 'test-update' update module");
         return MENDER_FAIL;
     }

--- a/tests/integration/src/modules/test-update-module.h
+++ b/tests/integration/src/modules/test-update-module.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#include "mender-utils.h"
+#include <mender/utils.h>
 
 mender_err_t test_update_module_register(void);
 


### PR DESCRIPTION
Rebase on top of main.

Only the last two commits are new:

* update the inclusions of header files after the reorganization
* use `mender_calloc` instead of  `calloc` in the test-update-module

We also need https://github.com/mendersoftware/mender-mcu/pull/155 for it to compile because of the weak functions
