### PR TITLE
fix: `deployment_status_cb` should take a `const char *desc`

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -120,3 +120,7 @@ CONFIG_ASSERT=y
 # CONFIG_PICOLIBC_ASSERT_VERBOSE=y
 # Useful logs from networking subsystem
 CONFIG_NET_LOG=y
+
+# Let's prevent surprises caused by type mismatches and other similar things
+# only causing compilation warnings, but potentially leading to fatal issues.
+CONFIG_COMPILER_WARNINGS_AS_ERRORS=y

--- a/src/main.c
+++ b/src/main.c
@@ -52,7 +52,7 @@ mender_network_release_cb(void) {
 }
 
 MENDER_FUNC_WEAK mender_err_t
-mender_deployment_status_cb(mender_deployment_status_t status, char *desc) {
+mender_deployment_status_cb(mender_deployment_status_t status, const char *desc) {
     LOG_DBG("deployment_status_cb: %s", desc);
     return MENDER_OK;
 }

--- a/src/utils/callbacks.h
+++ b/src/utils/callbacks.h
@@ -41,7 +41,7 @@ mender_err_t mender_network_release_cb(void);
  * @brief Callback to post the deployment status.
  * @return return MENDER_OK on success, MENDER_FAIL on error
  */
-mender_err_t mender_deployment_status_cb(mender_deployment_status_t status, char *desc);
+mender_err_t mender_deployment_status_cb(mender_deployment_status_t status, const char *desc);
 
 /**
  * @brief Callback to trigger a device reset, e.g. after a


### PR DESCRIPTION
This was changed to adapt to changes in the mender-mcu client, but was later reverted due to bad conflict resolution in 5065a57ccc26e04577b7bebdfdb9525bb3aa724b.

Ticket: MEN-7676
Changelog: none