### PR TITLE
chore: use const in test `mender_deployment_status_cb`

### DIFF
--- a/tests/integration/src/callbacks.c
+++ b/tests/integration/src/callbacks.c
@@ -35,7 +35,7 @@ mender_network_release_cb(void) {
 }
 
 mender_err_t
-mender_deployment_status_cb(mender_deployment_status_t status, char *desc) {
+mender_deployment_status_cb(mender_deployment_status_t status, const char *desc) {
     LOG_DBG("deployment_status_cb: %s", desc);
 #ifdef DEPLOYMENT_STATUS_CALLBACK
     DEPLOYMENT_STATUS_CALLBACK();


### PR DESCRIPTION
Follow-up from https://github.com/mendersoftware/mender-mcu-integration/pull/63