### PR TITLE
MEN-8254: Explicitly select hosted Mender USA

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -14,6 +14,8 @@ CONFIG_MENDER_LOG_LEVEL_INF=y
 # Demo polling intervals
 CONFIG_MENDER_CLIENT_UPDATE_POLL_INTERVAL=10
 CONFIG_MENDER_CLIENT_INVENTORY_REFRESH_INTERVAL=60
+# Mender Server selection - sets the Server URL and adds the certificates
+CONFIG_MENDER_SERVER_HOST_US=y
 
 
 ####################################


### PR DESCRIPTION
It is the default value, but by setting it in the application prj.conf we make it more intuitive for users to modify as desired after experimenting with interactive (but temporary) Kconfig settings.