### PR TITLE
ci: add rule to publish:tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,5 +137,5 @@ publish:tests:
     - cd mender-mcu-${MENDER_MCU_REVISION} && cp ../tests/integration/coverage.lcov .
     - coveralls report --build-number $PARENT_MENDER_MCU_PIPELINE_ID
   rules:
-    # Only publish coverage if the pipeline is triggered
-    - if: $CI_PIPELINE_SOURCE == "pipeline"
+    # Only publish coverage if the pipeline is triggered and the branch is protected
+    - if: $CI_PIPELINE_SOURCE == "pipeline" && $CI_COMMIT_REF_PROTECTED == "true"


### PR DESCRIPTION
Modified the rule in `publish:tests` to make sure it only runs on
protected branches, as that is when `test:integration` runs. Without
this, a trigger pipeline with an unprotected mender-mcu-integration
pipeline branch will run the `publish:tests` job without
`test:integration`