### PR TITLE
MEN-8292: Use an specific Device Type for integration tests

### DIFF
--- a/tests/integration/integration_tests.conf
+++ b/tests/integration/integration_tests.conf
@@ -6,6 +6,9 @@
 CONFIG_MENDER_SERVER_HOST="..."
 CONFIG_MENDER_SERVER_TENANT_TOKEN="..."
 
+# Custom device type
+CONFIG_MENDER_DEVICE_TYPE="test-device"
+
 # Faster poll interval for tests
 CONFIG_MENDER_CLIENT_UPDATE_POLL_INTERVAL=10
 

--- a/tests/integration/tests/test_mender_mcu.py
+++ b/tests/integration/tests/test_mender_mcu.py
@@ -29,7 +29,7 @@ import definitions
 def test_deployment_abort(server, get_build_dir):
 
     artifact_name = server.upload_artifact(
-        "test-artifact", device_types=("native_sim/native",)
+        "test-artifact", device_types=("test-device",)
     )
 
     download_body = r"""
@@ -55,7 +55,7 @@ def test_deployment_abort(server, get_build_dir):
     device.status.is_authenticated(timeout=60)
 
     artifact_name = server.upload_artifact(
-        "test-artifact", device_types=("native_sim/native",)
+        "test-artifact", device_types=("test-device",)
     )
     # Create deployment
     server.create_deployment(artifact_name, server.device_id, True)

--- a/tests/integration/tests/test_state_machine.py
+++ b/tests/integration/tests/test_state_machine.py
@@ -345,7 +345,7 @@ class TestStateMachineTransitions:
             server.accept_device()
             device.status.is_authenticated(timeout=60)
             artifact_name = server.upload_artifact(
-                "test-mender-mcu-state-machine", device_types=("native_sim/native",)
+                "test-mender-mcu-state-machine", device_types=("test-device",)
             )
 
             active_deployment = False


### PR DESCRIPTION
So that it is not in the way if/when we decide to modify the default `MENDER_DEVICE_TYPE`.