### PR TITLE
feat: migrate to Zephyr 4.2.0

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -76,12 +76,15 @@ CONFIG_ZVFS_OPEN_MAX=5
 # Zephyr logging
 ####################################
 CONFIG_LOG=y
+CONFIG_LOG_BUFFER_SIZE=2048
 # CONFIG_LOG_MODE_IMMEDIATE=y
 CONFIG_LOG_MODE_DEFERRED=y
 # flush oldest messages in the buffer; this will print the newest messages in case of buffer overflow
 CONFIG_LOG_MODE_OVERFLOW=y
 # speed up the logging; size of the executable the victim (use for testing only)
 CONFIG_LOG_SPEED=y
+# Direct dependency for LOG_OUTPUT_FORMAT_ISO8601_TIMESTAMP
+CONFIG_POSIX_C_LANG_SUPPORT_R=y
 # use ISO 8601 timestamp format in logs (required by the Mender Deployment Logs feature)
 CONFIG_LOG_OUTPUT_FORMAT_ISO8601_TIMESTAMP=y
 
@@ -129,3 +132,7 @@ CONFIG_NET_LOG=y
 # Let's prevent surprises caused by type mismatches and other similar things
 # only causing compilation warnings, but potentially leading to fatal issues.
 CONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
+# When enabled it adds ~3k overhead and causes sys_reboot to fail
+# because of stricter spinlock validation in Zephyr 4.2.0
+CONFIG_SPIN_VALIDATE=n

--- a/src/utils/netup.c
+++ b/src/utils/netup.c
@@ -74,7 +74,7 @@ wifi_connect(struct net_if *iface) {
 #endif
 
 static void
-event_handler(struct net_mgmt_event_callback *cb, uint32_t mgmt_event, struct net_if *iface) {
+event_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt_event, struct net_if *iface) {
     int i = 0;
 
     if (mgmt_event != NET_EVENT_IPV4_ADDR_ADD) {

--- a/sysbuild-mcuboot.conf
+++ b/sysbuild-mcuboot.conf
@@ -2,4 +2,4 @@
 SB_CONFIG_BOOTLOADER_MCUBOOT=y
 # Enable swap algorithm so we can revert in
 # case of a rollback
-SB_CONFIG_MCUBOOT_MODE_SWAP_WITHOUT_SCRATCH=y
+SB_CONFIG_MCUBOOT_MODE_SWAP_USING_MOVE=y

--- a/west.yml
+++ b/west.yml
@@ -9,10 +9,10 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v4.0.0
+      revision: v4.2.0
       import:
         name-allowlist:
-          - cmsis
+          - cmsis_6
           - mbedtls
           - mcuboot
           - hal_nxp


### PR DESCRIPTION
* replace deprecated `SB_CONFIG_MCUBOOT_MODE_SWAP_WITHOUT_SCRATCH` with `SB_CONFIG_MCUBOOT_MODE_SWAP_USING_MOVE`
From
https://docs.zephyrproject.org/latest/releases/migration-guide-4.1.html:
```
The Kconfig ``SB_CONFIG_MCUBOOT_MODE_SWAP_WITHOUT_SCRATCH`` has been deprecated and replaced
with ``SB_CONFIG_MCUBOOT_MODE_SWAP_USING_MOVE``, applications should be updated to select this
new symbol if they were selecting the old symbol.
```

* set `mgmt_event` type to `uint64_t`
From https://docs.zephyrproject.org/latest/releases/migration-guide-4.2.html:
The management event type is changed from `uint32_t` to `uint64_t`

* explicitly enable `POSIX_C_LANG_SUPPORT_R`
The General ISO C Library is needed to get the ISO 8601 timestamps we
need for the deployment logs.

* use cmsis-6
https://github.com/zephyrproject-rtos/example-application/commit/06bbb0a5e5adc5b6da0c0bb16919cebea931ee7e

* increase log buffer
The logging suddnely stop during a deployment. Inrease from default 1028
to 2046

* disable spin validation
From the Kconfig:
  There's a spinlock validation framework available when asserts are
  enabled. It adds a relatively hefty overhead (about 3k or so) to
  kernel code size, don't use on platforms known to be small.
If we have this enabled we will get an error when attempting to call the
reboot callback saying `... Context switching while holding lock!`

Ticket: MEN-8638
Changelog: Ticket