### PR TITLE
test: check if proc and deployment_id are empty

### DIFF
--- a/tests/integration/device.py
+++ b/tests/integration/device.py
@@ -143,6 +143,8 @@ class NativeSim:
         logger.info("Started device")
 
     def stop(self, stop_after=0):
+        if self.proc is None:
+            return
         time.sleep(stop_after)
         self.proc.terminate()
         self.proc.wait()

--- a/tests/integration/server.py
+++ b/tests/integration/server.py
@@ -90,6 +90,8 @@ class Server:
         self.deployment_id = ""
 
     def abort_deployment(self):
+        if not self.deployment_id:
+            return
         logger.info("Aborting deployment")
         return self.api_dev_deploy.with_auth(self.auth_token).call(
             "PUT",


### PR DESCRIPTION
Fixes NoneType AttributeErrors during teardown on compilation errors