### PR TITLE
ci: Change timeout from 120 to 180 for fail_rollback_verify_reboot test

### DIFF
--- a/tests/integration/tests/test_state_machine.py
+++ b/tests/integration/tests/test_state_machine.py
@@ -179,7 +179,7 @@ class TestStateMachineTransitions:
             ],
         },
         "fail_rollback_verify_reboot": {
-            "Timeout": 120,
+            "Timeout": 180,
             "FailureInStates": [
                 "MENDER_UPDATE_STATE_VERIFY_REBOOT",
                 "MENDER_UPDATE_STATE_ROLLBACK_VERIFY_REBOOT",


### PR DESCRIPTION
Not sure if this solve the issue but this particular test has been flaky for over a week and almost everytime pipeline restart result it ending up green.