### PR TITLE
chore: Use the floating 1.0.x revision of mender-mcu on zephyr-4.2.x

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -20,7 +20,7 @@ manifest:
           - hal_espressif
     - name: mender-mcu
       remote: mender
-      revision: v1.0.0
+      revision: 1.0.x
       path: modules/mender-mcu
       import: true
 


### PR DESCRIPTION
The zephyr-4.2.x branch is floating itself so it should not use a fixed version of mender-mcu. There is the `v1.0.0-zephyr-4.2.0` for that.

Ticket: None
Changelog: None