### PR TITLE
ci: Add a new job and test checking connectivity to eu.hosted.mender.io

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -189,6 +189,19 @@ test:integration:
     paths:
       - tests/integration/coverage.lcov
 
+test:smoke:eu-hosted:
+  extends: test:integration
+  variables:
+    TEST_AUTH_TOKEN: $EU_HOSTED_MENDER_TEST_ACCESS_TOKEN
+  script:
+    - cd /zephyr-workspace-cache
+    - west update --narrow -o=--depth=1 --path-cache /zephyr-workspace-cache
+    - cd modules/mender-mcu && git fetch mender ${MENDER_MCU_REVISION}
+    - git checkout FETCH_HEAD && cd -
+    - cd ${CI_PROJECT_DIR}/tests/integration
+    - pip install --ignore-installed --break-system-packages -r mender_server/backend/tests/requirements-integration.txt
+    - pytest --verbose --junitxml=results.xml --host eu.hosted.mender.io -m smoke
+
 publish:tests:
   stage: publish
   image: registry.gitlab.com/northern.tech/mender/mender-test-containers/codecov:master

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    smoke: Quick tests checking critical basic functionality

--- a/tests/integration/tests/test_mender_mcu.py
+++ b/tests/integration/tests/test_mender_mcu.py
@@ -77,3 +77,23 @@ def test_deployment_abort(server, get_build_dir, mac_address):
         logger.info("Deployment aborted")
     finally:
         device.stop()
+
+
+@pytest.mark.smoke
+def test_authenticate(server, get_build_dir, mac_address):
+    device = NativeSim(get_build_dir, stdout=True)
+    # Set host and tenant in the device
+    device.set_host(f"https://{server.host}")
+
+    # Temporary workaround for the PoC
+    device.set_tenant(server.get_tenant_token())
+    device.set_mac(mac_address)
+
+    try:
+        # Start device
+        device.start(pristine=True)
+        server.accept_device(mac_address)
+        device.status.is_authenticated(timeout=60)
+        logger.info("Authenticated")
+    finally:
+        device.stop()


### PR DESCRIPTION
A simple test only checking a device can authenticate to a server marked as `smoke` and run in a new CI job extending `tests:integration`, overriding the `TEST_AUTH_TOKEN`, using `eu.hosted.mender.io` as the host for tests and only running smoke tests (i.e. only this new one).

Ticket: MEN-9978
Changelog: None